### PR TITLE
Changed value '75+' to '>75' because of formatting issues

### DIFF
--- a/RuleSet.yaml
+++ b/RuleSet.yaml
@@ -53,7 +53,7 @@
             Description: '51-75'
         -
             Score: 3
-            Description: '75+'
+            Description: '>75'
 -
     Name: Benchmarks
     Id: 64ed80dc-d354-45a9-9a56-c32437306afa


### PR DESCRIPTION
Tested on Corvus.Testing using [this url](https://endimmfuncdev.azurewebsites.net/api/imm/github/corvus-dotnet/Corvus.Testing/showbadges?cache=false&definitionsBranch=feature/update-formatting-for-code-coverage&projectBranch=main) which displayed code coverage as 100% like it normally should 
